### PR TITLE
add build_machine_os_content.sh

### DIFF
--- a/build_machine_os_content.sh
+++ b/build_machine_os_content.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -xe
+
+source common.sh
+source build_utils.sh
+
+MOC_VERSION="$1"; shift || true
+BASE_RELEASE_PULLSPEC="$1"; shift || true
+HYPERKUBE_PULLSPEC="$1"; shift || true
+if [ -z "${MOC_VERSION}" -o -z "${BASE_RELEASE_PULLSPEC}" -o -z "${HYPERKUBE_PULLSPEC}" ]; then
+    echo "usage: $0 <output version> <base release pullspec> <hyperkube pullspec>" >&2
+    echo "example: $0 4.3.0.ipv6-2019-11-01-0001 registry.svc.ci.openshift.org/ocp/release:4.3.0-0.ci-2019-11-01-112322 quay.io/danwinship/hyperkube:ipv6" >&2
+    exit 1
+fi
+
+check_prereqs $MOC_STREAM || exit 1
+
+MOC_PULLSPEC=$(oc adm release extract --file=image-references ${BASE_RELEASE_PULLSPEC} | jq -r '.spec.tags | .[] | select(.name=="machine-os-content") | .from.name')
+
+DOCKERFILE=$(cat <<EOF
+FROM ${MOC_PULLSPEC} AS moc
+
+FROM ${HYPERKUBE_PULLSPEC} AS hyperkube
+
+FROM quay.io/coreos-assembler/coreos-assembler:latest AS build
+COPY --from=moc /srv/ /srv/
+COPY --from=hyperkube /usr/bin/hyperkube /overrides/usr/bin/hyperkube
+
+USER 0
+RUN coreos-assembler dev-overlay --repo /srv/repo --rev \$(find /srv -name *.commit | sed -Ee 's|.*objects/(.+)/(.+)\.commit|\1\2|' | head -1) --add-tree /overrides --output-ref origin-ci-dev
+
+FROM scratch
+COPY --from=build /srv/ /srv/
+ENTRYPOINT ["/noentry"]
+EOF
+)
+
+build_image_from_dockerfile "machine-os-content" $MOC_VERSION $MOC_STREAM "$DOCKERFILE"

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -15,6 +15,22 @@ function check_prereqs() {
     fi
 }
 
+function wait_for_build() {
+    name="$1"; shift
+
+    BUILD_POD=$(oc --config "${IPV6_KUBECONFIG}" get build "${name}" -o json | jq -r '.metadata.annotations["openshift.io/build.pod-name"]')
+    oc --config "${IPV6_KUBECONFIG}" wait --for condition=Ready pod "${BUILD_POD}" --timeout=240s
+    oc --config "${IPV6_KUBECONFIG}" logs -f "${BUILD_POD}"
+
+    BUILD_PHASE=$(oc --config "${IPV6_KUBECONFIG}" get build "${name}" -o json | jq -r .status.phase)
+    if [ "${BUILD_PHASE}" = "Complete" ]; then
+        BUILD_OUTPUT=$(oc --config "${IPV6_KUBECONFIG}" get build "${name}" -o json | jq -r .status.output.to.imageDigest)
+        echo "${name} built to ${BUILD_OUTPUT}"
+    else
+        echo "${name} build failed? Build phase is ${BUILD_PHASE}"
+    fi
+}
+
 function build_image() {
     iname="$1"; shift
     iversion="$1"; shift
@@ -47,15 +63,38 @@ spec:
       name: ${istream}:${iversion}
 EOF
 
-    BUILD_POD=$(oc --config "${IPV6_KUBECONFIG}" get build "${iname}-${iversion}" -o json | jq -r '.metadata.annotations["openshift.io/build.pod-name"]')
-    oc --config "${IPV6_KUBECONFIG}" wait --for condition=Ready pod "${BUILD_POD}" --timeout=240s
-    oc --config "${IPV6_KUBECONFIG}" logs -f "${BUILD_POD}"
+    wait_for_build ${iname}-${iversion}
+}
 
-    BUILD_PHASE=$(oc --config "${IPV6_KUBECONFIG}" get build "${iname}-${iversion}" -o json | jq -r .status.phase)
-    if [ "${BUILD_PHASE}" = "Complete" ]; then
-        BUILD_OUTPUT=$(oc --config "${IPV6_KUBECONFIG}" get build "${iname}-${iversion}" -o json | jq -r .status.output.to.imageDigest)
-        echo "${iname} built to ${BUILD_OUTPUT}"
-    else
-        echo "${iname} build failed? Build phase is ${BUILD_PHASE}"
-    fi
+function build_image_from_dockerfile() {
+    iname="$1"; shift
+    iversion="$1"; shift
+    istream="$1"; shift
+    dockerfile="$1"; shift
+
+    echo "Building ${iname} to ${istream}:${iversion} via custom Dockerfile"
+
+    dockerfile=$(echo "${dockerfile}" | sed -e 's/^/      /')
+
+    oc --config "${IPV6_KUBECONFIG}" apply -f - <<EOF
+apiVersion: build.openshift.io/v1
+kind: Build
+metadata:
+  name: ${iname}-${iversion}
+spec:
+  source:
+    type: Dockerfile
+    dockerfile: |
+${dockerfile}
+  strategy:
+    type: Docker
+    dockerStrategy:
+      imageOptimizationPolicy: SkipLayers
+  output:
+    to:
+      kind: ImageStreamTag
+      name: ${istream}:${iversion}
+EOF
+
+    wait_for_build ${iname}-${iversion}
 }

--- a/config_example.sh
+++ b/config_example.sh
@@ -47,3 +47,6 @@ CVO_STREAM=cluster-version-operator
 CVO_GIT_URI=https://github.com/russellb/cluster-version-operator.git
 CVO_GIT_REF=ipv6-hack
 CVO_DOCKERFILE=Dockerfile
+
+# machine-os-content build config
+MOC_STREAM=machine-os-content


### PR DESCRIPTION
This adds a script to build machine-os-content, based on https://github.com/danwinship/machine-os-content-ipv6/.

Unfortunately it doesn't quite work; the Dockerfile in that repo starts with:

    ARG MOC_REF
    FROM ${MOC_REF} AS moc
    
    ARG HYPERKUBE_REF
    FROM ${HYPERKUBE_REF} AS hyperkube

and that works under podman or imagebuilder, but it doesn't seem to build as a `Build` resource. It ends up failing with:

    Pulling image ${HYPERKUBE_REF} ...
    error: build error: failed to pull image: invalid reference format

(which looks like it's handling *one* FROM-with-build-arg, but can't handle *two*...)

I'm trying to figure out how to debug the build process more but figured I'd file this now since you seem to know at least a little bit more about Builds...