### PR TITLE
add build_cluster_dns_operator.sh

### DIFF
--- a/build_cluster_dns_operator.sh
+++ b/build_cluster_dns_operator.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -xe
+
+source common.sh
+source build_utils.sh
+
+DNS_VERSION="$1"
+if [ -z "${DNS_VERSION}" ]; then
+    echo "usage: $0 <cluster-dns-operator version>" >&2
+    echo "example: $0 4.3.0.ipv6-2019-11-01-0001" >&2
+    exit 1
+fi
+
+check_prereqs $DNS_STREAM || exit 1
+
+build_image "cluster-dns-operator" $DNS_VERSION $DNS_STREAM \
+             $DNS_GIT_URI $DNS_GIT_REF $DNS_DOCKERFILE

--- a/config_example.sh
+++ b/config_example.sh
@@ -17,6 +17,12 @@ IPV6_PULLSECRET=ipv6-pullsecret
 
 ## Specific modules
 
+# cluster-dns-operator build config
+DNS_STREAM=cluster-dns-operator
+DNS_GIT_URI=https://github.com/danwinship/cluster-dns-operator.git
+DNS_GIT_REF=ipv6-aws
+DNS_DOCKERFILE=Dockerfile
+
 # cluster-kube-apiserver-operator build config
 CKAO_STREAM=cluster-kube-apiserver-operator
 CKAO_GIT_URI=https://github.com/danwinship/cluster-kube-apiserver-operator.git

--- a/config_example.sh
+++ b/config_example.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+## Generic configuration
+
 # A namespace where builds will be executed
 IPV6_NAMESPACE=ipv6
 
@@ -13,29 +15,7 @@ IPV6_KUBECONFIG=ipv6-kubeconfig
 # images referenced by the payload - are hosted
 IPV6_PULLSECRET=ipv6-pullsecret
 
-# machine-config-operator build config
-MCO_STREAM=machine-config-operator
-MCO_GIT_URI=https://github.com/russellb/machine-config-operator.git
-MCO_GIT_REF=ipv6
-MCO_DOCKERFILE=Dockerfile
-
-# cluster-network-operator build config
-CNO_STREAM=cluster-network-operator
-CNO_GIT_URI=https://github.com/markmc/cluster-network-operator.git
-CNO_GIT_REF=ipv6-hack
-CNO_DOCKERFILE=Dockerfile
-
-# ovn-kubernetes build config
-OVNKUBE_STREAM=ovn-kubernetes
-OVNKUBE_GIT_URI=https://github.com/markmc/ovn-kubernetes.git
-OVNKUBE_GIT_REF=ipv6-hack
-OVNKUBE_DOCKERFILE=Dockerfile
-
-# hyperkube build config
-HYPERKUBE_STREAM=hyperkube
-HYPERKUBE_GIT_URI=https://github.com/danwinship/origin.git
-HYPERKUBE_GIT_REF=ipv6
-HYPERKUBE_DOCKERFILE=images/hyperkube/Dockerfile.rhel
+## Specific modules
 
 # cluster-kube-apiserver-operator build config
 CKAO_STREAM=cluster-kube-apiserver-operator
@@ -43,10 +23,35 @@ CKAO_GIT_URI=https://github.com/danwinship/cluster-kube-apiserver-operator.git
 CKAO_GIT_REF=ipv6-bind
 CKAO_DOCKERFILE=Dockerfile
 
+# cluster-network-operator build config
+CNO_STREAM=cluster-network-operator
+CNO_GIT_URI=https://github.com/markmc/cluster-network-operator.git
+CNO_GIT_REF=ipv6-hack
+CNO_DOCKERFILE=Dockerfile
+
+# cluster-version-operator build config
 CVO_STREAM=cluster-version-operator
 CVO_GIT_URI=https://github.com/russellb/cluster-version-operator.git
 CVO_GIT_REF=ipv6-hack
 CVO_DOCKERFILE=Dockerfile
 
+# hyperkube build config
+HYPERKUBE_STREAM=hyperkube
+HYPERKUBE_GIT_URI=https://github.com/danwinship/origin.git
+HYPERKUBE_GIT_REF=ipv6
+HYPERKUBE_DOCKERFILE=images/hyperkube/Dockerfile.rhel
+
+# machine-config-operator build config
+MCO_STREAM=machine-config-operator
+MCO_GIT_URI=https://github.com/russellb/machine-config-operator.git
+MCO_GIT_REF=ipv6
+MCO_DOCKERFILE=Dockerfile
+
 # machine-os-content build config
 MOC_STREAM=machine-os-content
+
+# ovn-kubernetes build config
+OVNKUBE_STREAM=ovn-kubernetes
+OVNKUBE_GIT_URI=https://github.com/markmc/ovn-kubernetes.git
+OVNKUBE_GIT_REF=ipv6-hack
+OVNKUBE_DOCKERFILE=Dockerfile


### PR DESCRIPTION
AWS only offers internal DNS over v4, so the coredns pods need to run as hostNetwork to be able to access that. https://github.com/danwinship/cluster-dns-operator/commit/0ac72bd7 does that.