### PR TITLE
Use the correct base image for builds

### DIFF
--- a/build_utils.sh
+++ b/build_utils.sh
@@ -57,6 +57,10 @@ spec:
     dockerStrategy:
       imageOptimizationPolicy: SkipLayers
       dockerfilePath: ${dockerfile}
+      from:
+        kind: ImageStreamTag
+        namespace: ocp
+        name: ${IPV6_BASE}:base
   output:
     to:
       kind: ImageStreamTag

--- a/config.sh
+++ b/config.sh
@@ -5,6 +5,9 @@
 # A namespace where builds will be executed
 IPV6_NAMESPACE=ipv6
 
+# The image stream (under the ocp namespace) where our 'base' image is tagged
+IPV6_BASE=4.3
+
 # Image stream where the release will be published to
 IPV6_RELEASE_STREAM=release
 


### PR DESCRIPTION
All our builds are basing on the openshift/origin-base and it turns out that each release has a base image that should be used for builds for that release - e.g. for 4.3 it is ocp/4.3:base

Just like ci-operator initiated builds, set this up by using the 'from' config for the docker build strategy. See https://docs.openshift.com/container-platform/4.3/builds/build-strategies.html#builds-strategy-docker-from-image_build-strategies

The equivalent ci-operator config is:

```
  base_images:
    base:
      name: "4.3"
      namespace: ocp
      tag: base
```

You can tell this is working because the log says:

```
  Pulling image docker-registry.default.svc:5000/ocp/4.3@sha256:8f4728ddd27d43b8afc0b46f804db14dc2df87c9ddcc95b85a62e64fb03c4d2f
```

rather than:

```
  Pulling image openshift/origin-base
```